### PR TITLE
Set a path to map

### DIFF
--- a/Source/Response+SwiftyJSONMapper.swift
+++ b/Source/Response+SwiftyJSONMapper.swift
@@ -13,22 +13,23 @@ public extension Response {
 
     /// Maps data received from the signal into an object which implements the ALSwiftyJSONAble protocol.
     /// If the conversion fails, the signal errors.
-    public func mapObject<T: ALSwiftyJSONAble>(type:T.Type) throws -> T {
+    public func mapObject<T: ALSwiftyJSONAble>(type:T.Type, path: [JSONSubscriptType]) throws -> T {
         let jsonObject = try mapJSON()
         
-        guard let mappedObject = T(jsonData: JSON(jsonObject)) else {
+        let jsonData = JSON(jsonObject)[path]
+        guard let mappedObject = T(jsonData: jsonData) else {
             throw Moya.Error.jsonMapping(self)
         }
         
         return mappedObject
     }
-
+    
     /// Maps data received from the signal into an array of objects which implement the ALSwiftyJSONAble protocol
     /// If the conversion fails, the signal errors.
-    public func mapArray<T: ALSwiftyJSONAble>(type:T.Type) throws -> [T] {
+    public func mapArray<T: ALSwiftyJSONAble>(type:T.Type, path: [JSONSubscriptType]) throws -> [T] {
         let jsonObject = try mapJSON()
         
-        let mappedArray = JSON(jsonObject)
+        let mappedArray = JSON(jsonObject)[path]
         let mappedObjectsArray = mappedArray.arrayValue.flatMap { T(jsonData: $0) }
         
         return mappedObjectsArray

--- a/Source/RxSwift/Observable+SwiftyJSONMapper.swift
+++ b/Source/RxSwift/Observable+SwiftyJSONMapper.swift
@@ -15,17 +15,23 @@ public extension ObservableType where E == Response {
 
     /// Maps data received from the signal into an object which implements the ALSwiftyJSONAble protocol.
     /// If the conversion fails, the signal errors.
-    public func mapObject<T: ALSwiftyJSONAble>(type: T.Type) -> Observable<T> {
+    public func mapObject<T: ALSwiftyJSONAble>(type: T.Type, path: [JSONSubscriptType] = []) -> Observable<T> {
         return flatMap { response -> Observable<T> in
-            return Observable.just(try response.mapObject(type: type))
+            return Observable.just(try response.mapObject(type: type, path: path))
         }
     }
-
+    public func mapObject<T: ALSwiftyJSONAble>(type: T.Type, path: JSONSubscriptType) -> Observable<T> {
+        return self.mapObject(type: type, path: [path])
+    }
+    
     /// Maps data received from the signal into an array of objects which implement the ALSwiftyJSONAble protocol.
     /// If the conversion fails, the signal errors.
-    public func mapArray<T: ALSwiftyJSONAble>(type: T.Type) -> Observable<[T]> {
+    public func mapArray<T: ALSwiftyJSONAble>(type: T.Type, path: [JSONSubscriptType] = []) -> Observable<[T]> {
         return flatMap { response -> Observable<[T]> in
-            return Observable.just(try response.mapArray(type: type))
+            return Observable.just(try response.mapArray(type: type, path: path))
         }
+    }
+    public func mapArray<T: ALSwiftyJSONAble>(type: T.Type, path: JSONSubscriptType) -> Observable<[T]> {
+        return self.mapArray(type: type, path: [path])
     }
 }


### PR DESCRIPTION
set a path to where the json should search the content

works like this:

``` Swift
  .mapArray(type: MyEntry.self) // search on root
  .mapArray(type: MyEntry.self, path: "data") // search on { "data": ... }
  .mapArray(type: MyEntry.self, path: ["data"]) // search on { "data": ... }
  .mapArray(type: MyEntry.self, path: ["data","content"]) // search on { "data": { " content": ... } }
```

on `mapArray` and `mapObject`
