### PR TITLE
Upgrade Moya to v14

### DIFF
--- a/Example/Moya-SwiftyJSONMapper.xcodeproj/project.pbxproj
+++ b/Example/Moya-SwiftyJSONMapper.xcodeproj/project.pbxproj
@@ -308,7 +308,6 @@
 				"${BUILT_PRODUCTS_DIR}/Moya/Moya.framework",
 				"${BUILT_PRODUCTS_DIR}/Moya-SwiftyJSONMapper/Moya_SwiftyJSONMapper.framework",
 				"${BUILT_PRODUCTS_DIR}/ReactiveSwift/ReactiveSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/Result/Result.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
 			);
@@ -318,7 +317,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Moya.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Moya_SwiftyJSONMapper.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReactiveSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Result.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
 			);
@@ -338,7 +336,6 @@
 				"${BUILT_PRODUCTS_DIR}/Moya/Moya.framework",
 				"${BUILT_PRODUCTS_DIR}/Moya-SwiftyJSONMapper/Moya_SwiftyJSONMapper.framework",
 				"${BUILT_PRODUCTS_DIR}/ReactiveSwift/ReactiveSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/Result/Result.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
 			);
@@ -348,7 +345,6 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Moya.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Moya_SwiftyJSONMapper.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReactiveSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Result.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
 			);
@@ -493,7 +489,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -543,7 +539,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -561,6 +557,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = FFLRU7747R;
 				INFOPLIST_FILE = "Moya-SwiftyJSONMapper/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";
@@ -579,6 +576,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = FFLRU7747R;
 				INFOPLIST_FILE = "Moya-SwiftyJSONMapper/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.$(PRODUCT_NAME:rfc1034identifier)";

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,7 +1,7 @@
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 def shared_pods
     pod 'Moya-SwiftyJSONMapper', :path => '../'
@@ -24,7 +24,7 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
       if swift5Targets.include? target.name
         target.build_configurations.each do |config|
-          config.build_settings['SWIFT_VERSION'] = '5.0'
+          config.build_settings['SWIFT_VERSION'] = '5.1'
         end
       else
         target.build_configurations.each do |config|

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,31 +1,28 @@
 PODS:
-  - Alamofire (4.9.1)
-  - Moya (13.0.1):
-    - Moya/Core (= 13.0.1)
-  - Moya-SwiftyJSONMapper (4.0.0):
-    - Moya-SwiftyJSONMapper/Core (= 4.0.0)
-  - Moya-SwiftyJSONMapper/Core (4.0.0):
-    - Moya (~> 13.0.1)
+  - Alamofire (5.2.1)
+  - Moya (14.0.0):
+    - Moya/Core (= 14.0.0)
+  - Moya-SwiftyJSONMapper (6.0.0):
+    - Moya-SwiftyJSONMapper/Core (= 6.0.0)
+  - Moya-SwiftyJSONMapper/Core (6.0.0):
+    - Moya (~> 14)
     - SwiftyJSON
-  - Moya-SwiftyJSONMapper/ReactiveCocoa (4.0.0):
+  - Moya-SwiftyJSONMapper/ReactiveCocoa (6.0.0):
     - Moya-SwiftyJSONMapper/Core
     - Moya/ReactiveSwift
-  - Moya-SwiftyJSONMapper/RxSwift (4.0.0):
+  - Moya-SwiftyJSONMapper/RxSwift (6.0.0):
     - Moya-SwiftyJSONMapper/Core
     - Moya/RxSwift
-  - Moya/Core (13.0.1):
-    - Alamofire (~> 4.1)
-    - Result (~> 4.1)
-  - Moya/ReactiveSwift (13.0.1):
+  - Moya/Core (14.0.0):
+    - Alamofire (~> 5.0)
+  - Moya/ReactiveSwift (14.0.0):
     - Moya/Core
-    - ReactiveSwift (~> 5.0)
-  - Moya/RxSwift (13.0.1):
+    - ReactiveSwift (~> 6.0)
+  - Moya/RxSwift (14.0.0):
     - Moya/Core
-    - RxSwift (~> 4.0)
-  - ReactiveSwift (5.0.1):
-    - Result (~> 4.1)
-  - Result (4.1.0)
-  - RxSwift (4.5.0)
+    - RxSwift (~> 5.0)
+  - ReactiveSwift (6.3.0)
+  - RxSwift (5.1.1)
   - SwiftyJSON (5.0.0)
 
 DEPENDENCIES:
@@ -38,7 +35,6 @@ SPEC REPOS:
     - Alamofire
     - Moya
     - ReactiveSwift
-    - Result
     - RxSwift
     - SwiftyJSON
 
@@ -47,14 +43,13 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Alamofire: 85e8a02c69d6020a0d734f6054870d7ecb75cf18
-  Moya: f4a4b80ff2f8a4ffc208dfb31cd91636622fee6e
-  Moya-SwiftyJSONMapper: 46766fd2fa3543af73cb6e0674b732417e1c7a83
-  ReactiveSwift: cac20a5bbe560c5806bd29c0fccf90d03b996ac1
-  Result: bd966fac789cc6c1563440b348ab2598cc24d5c7
-  RxSwift: f172070dfd1a93d70a9ab97a5a01166206e1c575
+  Alamofire: e911732990610fe89af59ac0077f923d72dc3dfd
+  Moya: 5b45dacb75adb009f97fde91c204c1e565d31916
+  Moya-SwiftyJSONMapper: 2441e3b3406b7533ee1960caa21187b691adfddc
+  ReactiveSwift: 7937f26ec18d555e2a99352bd0a8b2817d1f042d
+  RxSwift: 81470a2074fa8780320ea5fe4102807cb7118178
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
 
-PODFILE CHECKSUM: b2070400d16a827b30d7177b42586267696afe2d
+PODFILE CHECKSUM: 0f2d4be57b04bf5af80df2e0907c21fb52ce44d5
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.3

--- a/Moya-SwiftyJSONMapper.podspec
+++ b/Moya-SwiftyJSONMapper.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "Moya-SwiftyJSONMapper"
-  s.version          = "5.0.0"
+  s.version          = "6.0.0"
   s.summary          = "Map objects through SwiftyJSON in combination with Moya"
   s.description  = <<-EOS
     [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON) bindings for
@@ -23,17 +23,17 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/AvdLee/Moya-SwiftyJSONMapper.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/twannl'
 
-  s.ios.deployment_target = '8.0'
-  s.tvos.deployment_target = '9.0'
+  s.ios.deployment_target = '10.0'
+  s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '3.0'
   s.requires_arc = true
-  s.swift_version = '5.1'  
+  s.swift_version = '5.1'
 
   s.default_subspec = "Core"
 
   s.subspec "Core" do |ss|
     ss.source_files  = "Source/*.swift"
-    ss.dependency "Moya", "~> 13.0.1"
+    ss.dependency "Moya", "~> 14"
     ss.dependency "SwiftyJSON"
     ss.framework  = "Foundation"
   end

--- a/Source/RxSwift/PrimitiveSequence+SwiftyJSONMapper.swift
+++ b/Source/RxSwift/PrimitiveSequence+SwiftyJSONMapper.swift
@@ -11,7 +11,7 @@ import Moya
 import SwiftyJSON
 
 /// Extension for processing Responses into Mappable objects through ObjectMapper
-extension PrimitiveSequence where TraitType == SingleTrait, ElementType == Response {
+extension PrimitiveSequence where Trait == SingleTrait, Element == Response {
 
     /// Maps data received from the signal into an object which implements the ALSwiftyJSONAble protocol.
     /// If the conversion fails, the signal errors.


### PR DESCRIPTION
First of all, thanks a lot for creating/maintaining this awesome project. 

I was trying to upgrade Moya to the latest version in one of my projects and found `Moya-SwiftyJSONMapper` does not support Moya 14 yet. So here comes this PR.

This PR contains the following changes:

- Upgrade dependency `Moya` to version `14.0.0` (the latest version at the time)
- Upgrade minimum deployment targets to match the ones in [Moya.podspec](https://github.com/Moya/Moya/blob/master/Moya.podspec)
- Upgrade `cocoapods` to `1.9.3` (the latest version at the time)
- Upgrade Swift version to 5.1 in the example project to match the one in `podspec`
- Bump version to `6.0.0`

Any comments/suggestions are hugely welcomed 🙏 
